### PR TITLE
Note that import of text with no type is not prohibited

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -99,7 +99,7 @@ contributors: Eemeli Aro
     <p>The actual process performed is host-defined, but typically consists of performing whatever I/O operations are necessary to load the appropriate Module Record. Multiple different (_referrer_, _moduleRequest_.[[Specifer]], _moduleRequest_.[[Attributes]]) triples may map to the same Module Record instance. The actual mapping semantics is host-defined but typically a normalization process is applied to _specifier_ as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
 
     <emu-note>
-      <p>The above text implies that hosts *must* support JSON modules imported with `type: "json"` (if it completes normally), but it doesn't prohibit hosts from supporting JSON modules imported with no type specified. Some environments (for example, web browsers) plan to require `with { type: "json" }`, and environments which want to restrict themselves to a compatible subset would do so as well.</p>
+      <p>The above text implies that hosts *must* support JSON modules imported with `type: "json"` (if it completes normally), but it doesn't prohibit hosts from supporting JSON modules imported with no type specified. Some environments (for example, web browsers) plan to require `with { type: "json" }`, and environments which want to restrict themselves to a compatible subset would do so as well. <ins>Similarly, hosts are not prohibited from supporting the import of text modules with no type specified.</ins></p>
     </emu-note>
 
     <emu-note>


### PR DESCRIPTION
Closes #1

@nicolo-ribaudo, is this what you meant? Eventually, the text here will almost certainly need to account for `type: 'bytes'` as well, which [also](https://tc39.es/proposal-import-bytes/#sec-HostLoadImportedModule) modifies this note, but a bit differently.