### PR TITLE
Clarify that UTF-8 is not explicitly the only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ with which a file may be imported as a string value:
 import text from "path/to/file.txt" with { type: "text" };
 ```
 
-No affordance for defining the encoding ought to be given,
-with all files parsed as UTF-8.
+No affordance for defining the encoding ought to be given.
 
 ## Shortcomings
 
-Importing non-UTF-8 text will require importing it as an Uint8Array,
+Importing text with an encoding defined within JavaScript
+will require importing it as an Uint8Array,
 and explicitly decoding it:
 
 ```js


### PR DESCRIPTION
Closes #2 

As noted by @sapphi-red, leaving out explicit control of the encoding doesn't mean that it always defaults to UTF-8.

The intent is for `import: 'text'` to match the behaviour of `import: 'json'` in this respect.